### PR TITLE
Add ROCRO_Prefix and Fix error for rbenv install

### DIFF
--- a/2.6.6-buster/Dockerfile
+++ b/2.6.6-buster/Dockerfile
@@ -1,10 +1,8 @@
 FROM ruby:2.6.6-slim-buster
 
-ENV SETUP_HOME /opt/ruby
-ENV RBENV_ROOT ${SETUP_HOME}/rbenv
+ENV ROCRO_SETUP_HOME /opt/ruby
+ENV RBENV_ROOT ${ROCRO_SETUP_HOME}/rbenv
 ENV PATH ${RBENV_ROOT}/shims:${RBENV_ROOT}/bin:${PATH}
-
-ENV CONCHOID_DOCKER_RBENV_HOME /conchoid/docker-rbenv
 
 # install build deps and set locale
 RUN apt-get update && apt-get install -y \
@@ -47,6 +45,7 @@ RUN RUBY_BUILD_VERSION="v20201005" \
   && git clone https://github.com/rbenv/ruby-build.git "${RUBY_BUILD_DIR}" \
   && cd "${RUBY_BUILD_DIR}" \
   && git checkout "${RUBY_BUILD_VERSION}" \
+  && ./install.sh \
   && rm -rf .git
 
 # install runtimes and bundler

--- a/2.6.6-stretch/Dockerfile
+++ b/2.6.6-stretch/Dockerfile
@@ -1,10 +1,8 @@
 FROM ruby:2.6.6-slim-stretch
 
-ENV SETUP_HOME /opt/ruby
-ENV RBENV_ROOT ${SETUP_HOME}/rbenv
+ENV ROCRO_SETUP_HOME /opt/ruby
+ENV RBENV_ROOT ${ROCRO_SETUP_HOME}/rbenv
 ENV PATH ${RBENV_ROOT}/shims:${RBENV_ROOT}/bin:${PATH}
-
-ENV CONCHOID_DOCKER_RBENV_HOME /conchoid/docker-rbenv
 
 # install build deps and set locale
 RUN apt-get update && apt-get install -y \
@@ -46,6 +44,7 @@ RUN RUBY_BUILD_VERSION="v20201005" \
   && git clone https://github.com/rbenv/ruby-build.git "${RUBY_BUILD_DIR}" \
   && cd "${RUBY_BUILD_DIR}" \
   && git checkout "${RUBY_BUILD_VERSION}" \
+  && ./install.sh \
   && rm -rf .git
 
 # install runtimes and bundler


### PR DESCRIPTION
tractrix/codelift#2281 に対する対応です。

DockerHubに以下のタグ名でpushしています。
conchoid/docker-rbenv:v1.1.2-5-2.6.6-stretch