### PR TITLE
Update to trixie / ruby to 3.3.10

### DIFF
--- a/.update/update.md
+++ b/.update/update.md
@@ -1,0 +1,58 @@
+# Dockerfile ベースイメージ更新手順
+
+## 概要
+docker-rbenv/3.3-bookworm/Dockerfileのベースイメージを `ruby:3.3.5-slim-bookworm` (Debian 12) から `ruby:3.3.10-slim-trixie` (Debian 13) に更新する。
+
+## 更新手順
+
+### 1. ベースイメージの更新
+Dockerfileの1行目を以下のように変更する：
+
+**変更前:**
+```dockerfile
+FROM ruby:3.3.5-slim-bookworm
+```
+
+**変更後:**
+```dockerfile
+FROM ruby:3.3.10-slim-trixie
+```
+
+**注意:** `ruby:3.3.5-slim-trixie` タグが存在しないため、`ruby:3.3.10-slim-trixie` を使用する。
+
+### 2. 動作確認
+以下のコマンドでDockerイメージをビルドし、正常に動作することを確認する：
+
+```bash
+cd docker-rbenv
+docker build -t conchoid/docker-rbenv:v1.3.2-1-3.3.10-trixie -f 3.3-trixie/Dockerfile .
+```
+
+**注意:** rbenvのバージョンはv1.3.2を使用する。
+
+### 3. 互換性チェック
+Debian 13への更新により、以下の点を確認する：
+
+- パッケージの互換性（apt-getでインストールしているパッケージが利用可能か）
+- rbenvの動作確認
+- ruby-buildの動作確認
+- Ruby各バージョン（3.0.7, 3.1.7, 3.2.9, 3.3.10）のインストール確認
+- bundlerのインストール確認
+- ロケール設定の確認
+- libssl1.0-devのインストール確認（Ubuntu bionic-securityリポジトリからの取得）
+
+### 4. テスト実行
+実際のRubyプロジェクトでイメージを使用し、以下を確認する：
+
+- ビルドが正常に完了するか
+- 依存関係の解決が正常に行われるか
+- 実行時エラーが発生しないか
+- rbenvによるRubyバージョン切り替えが正常に動作するか
+
+## 注意事項
+- Debian 13 (trixie) は比較的新しいリリースのため、一部のパッケージやツールのバージョンが変更されている可能性がある
+- 問題が発生した場合は、パッケージのバージョン指定や代替パッケージの検討が必要になる場合がある
+- **apt-getでインストールしているライブラリは必要なライブラリなので、trixieでもインストールを行う必要がある**
+- libssl1.0-devはUbuntu bionic-securityリポジトリから取得しているため、trixieでも同様の設定が必要か確認すること
+- ビルド後は、rbenv、ruby-build、各Rubyバージョン、bundlerが正常にインストールされていることを確認すること
+

--- a/3.3-trixie/Dockerfile
+++ b/3.3-trixie/Dockerfile
@@ -1,0 +1,69 @@
+FROM ruby:3.3.10-slim-trixie
+
+ENV ROCRO_SETUP_HOME /opt/ruby
+ENV RBENV_ROOT ${ROCRO_SETUP_HOME}/rbenv
+ENV PATH ${RBENV_ROOT}/shims:${RBENV_ROOT}/bin:${PATH}
+
+# install build deps and set locale
+RUN apt-get update --allow-releaseinfo-change && apt-get install -y \
+      autoconf \
+      bison \
+      bzip2 \
+      build-essential \
+      curl \
+      gcc \
+      git \
+      gnupg \
+      libffi-dev \
+      libgdbm-dev \
+      libgdbm-compat-dev \
+      libncurses5-dev \
+      libreadline6-dev \
+      libssl-dev \
+      libyaml-dev \
+      locales \
+      zlib1g-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" > /etc/apt/sources.list.d/bionic-security.list \
+    && curl -fsSL http://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x3B4FE6ACC0B21F32 | gpg --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-bionic.gpg \
+    && apt-get update && apt-cache policy libssl1.0-dev && apt-get install -y libssl1.0-dev \
+    && rm -f /etc/apt/sources.list.d/bionic-security.list /etc/apt/trusted.gpg.d/ubuntu-bionic.gpg
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV RUBYOPT -EUTF-8
+
+# install rbenv
+RUN RBENV_VERSION="v1.3.2" \
+  && git clone https://github.com/rbenv/rbenv.git "${RBENV_ROOT}" \
+  && cd "${RBENV_ROOT}" \
+  && git checkout "${RBENV_VERSION}" \
+  && src/configure && make -C src \
+  && rm -rf .git
+
+# install ruby-build
+RUN RUBY_BUILD_VERSION="v20260113" \
+  && RUBY_BUILD_DIR="${RBENV_ROOT}/plugins/ruby-build" \
+  && mkdir -p "${RBENV_ROOT}/plugins" \
+  && git clone https://github.com/rbenv/ruby-build.git "${RUBY_BUILD_DIR}" \
+  && cd "${RUBY_BUILD_DIR}" \
+  && git checkout "${RUBY_BUILD_VERSION}" \
+  && ./install.sh \
+  && rm -rf .git
+
+# install runtimes and bundler
+RUN BUNDLER2_VERSION="2.4.22" \
+  && unset GEM_HOME \
+  && gem install bundler -v ${BUNDLER2_VERSION} \
+  && for version in "3.1.7" "3.2.9" "3.3.10"; do \
+    rbenv install "${version}" \
+    && rbenv global "${version}" \
+    && gem install bundler -v ${BUNDLER2_VERSION} \
+    && rm -rf ${RBENV_ROOT}/versions/${version}/share \
+    && ls -1d ${RBENV_ROOT}/versions/${version}/lib/ruby/gems/3.*/doc | xargs rm -rf \
+  ; done \
+  && rbenv global system
+


### PR DESCRIPTION
base imageをtrixieへ更新して rubyを3.3.10を利用するように更新しました。

DockerHubには以下のタグでpushしています。
`conchoid/docker-rbenv:v1.3.2-1-3.3.10-trixie`
